### PR TITLE
System environment variable to use DB implementation locally `THRONE_USE_DB`

### DIFF
--- a/api/persistence/__init__.py
+++ b/api/persistence/__init__.py
@@ -14,7 +14,7 @@ from .stores.washroom_store import WashroomStore
 
 import os
 
-if os.environ.get("IS_LAMBDA"):
+if os.environ.get("IS_LAMBDA") or os.environ.get("THRONE_USE_DB"):
     # TODO: Change these to DB implementations
     __amenity_persistence = AmenitiesStubPersistence()
     __building_persistence = BuildingsStubPersistence()

--- a/docs/SETUP.md
+++ b/docs/SETUP.md
@@ -111,3 +111,14 @@ These steps install the dependencies required for deploying to AWS.
     ```shell
     serverless remove
     ```
+## System variables
+
+To define a system variable use the following snippet:
+
+```
+$ export <variable name>=<variable value>
+```
+
+Below is a list of system variables utilized by the Throne backend service.
+
+- `THRONE_USE_DB` - When defined will use the DB persistence layer rather than the stubs. Used for testing DB implementation locally.


### PR DESCRIPTION
- Adds the system environment variable `THRONE_USE_DB` which when defined will use the DB implementation for the persistence layer.