### PR TITLE
Update reserved concurrency limit

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -53,3 +53,5 @@ package:
   - LICENSE
   - CODEOWNERS
   - README.md
+  - package.json
+  - package-lock.json


### PR DESCRIPTION
This PR updates the reserved concurrency limit for our Lambda function. This limit is the maximum number of instances of our Lambda that can be spawned in response to API requests. I have set this to 60 to avoid reaching the maximum number of database connections for RDS. After we have 60 instances of our Lambda running, existing requests will be throttled and handled by one of the existing 60 instances when they are available to do so. This is good as our code won't crash if it can't connect to the DB due to the maximum number of connections being reached, but we will have to see how this works in tandem with users using the application and if they experience noticeable slowdowns after we reach the concurrency limit.

Closes #173 